### PR TITLE
Remove unnecessary middleclass rock dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Changed:
+- [#33](https://github.com/BixData/lua-long/issues/33) Remove middleclass dependency
+
 ## [1.0.3-1] - 2019-06-04
 ### Fixed:
 - [#30](https://github.com/BixData/lua-long/issues/30) gzip extraction error when installing with luarocks

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Usage
 ```lua
 local Long = require('long')
 
-local longVal = Long:new(0xFFFFFFFF, 0x7FFFFFFF)
+local longVal = Long.new(0xFFFFFFFF, 0x7FFFFFFF)
 print(longVal:toString())
 ...
 ```
@@ -44,7 +44,7 @@ print(longVal:toString())
 API
 ---
 
-#### Long:new(low, high=, unsigned=)
+#### Long.new(low, high=, unsigned=)
 
 Constructs a 64 bit two's-complement integer, given its low and high 32 bit values as *signed* integers.
 See the from* functions below for more convenient ways of constructing Longs.

--- a/long-2.0.0-0.rockspec
+++ b/long-2.0.0-0.rockspec
@@ -1,8 +1,8 @@
 package = "long"
-version = "1.0.3-1"
+version = "2.0.0-0"
 source = {
-  url = "https://github.com/BixData/lua-long/archive/1.0.3-1.tar.gz",
-  dir = "lua-long-1.0.3-1"
+  url = "https://github.com/BixData/lua-long/archive/2.0.0-0.tar.gz",
+  dir = "lua-long-2.0.0-0"
 }
 description = {
   summary = "A pure Lua class representing a 64 bit two's-complement integer value",
@@ -15,8 +15,7 @@ description = {
 }
 dependencies = {
   "bit32 <= 5.3.2-0",
-  "lua >= 5.1, < 5.3",
-  "middleclass <= 4.1-0"
+  "lua >= 5.1, < 5.3"
 }
 build = {
   type = "builtin",

--- a/spec/long_spec.lua
+++ b/spec/long_spec.lua
@@ -17,7 +17,7 @@
 local Long = require 'long'
 
 it('basic', function()
-  local longVal = Long:new(0xFFFFFFFF, 0x7FFFFFFF)
+  local longVal = Long.new(0xFFFFFFFF, 0x7FFFFFFF)
   assert.equal(9223372036854775807, longVal:toNumber())
   assert.equal("9223372036854775807", longVal:toString())
   local longVal2 = Long.fromValue(longVal)
@@ -27,7 +27,7 @@ it('basic', function()
 end)
 
 it('isLong', function()
-  local longVal = Long:new(0xFFFFFFFF, 0x7FFFFFFF)
+  local longVal = Long.new(0xFFFFFFFF, 0x7FFFFFFF)
   assert.equal(Long.isLong(longVal), true)
 end)
 
@@ -65,7 +65,7 @@ describe('unsigned', function()
   end)
 
   it('construct_highlow', function()
-    local longVal = Long:new(0xFFFFFFFF, 0xFFFFFFFF, true)
+    local longVal = Long.new(0xFFFFFFFF, 0xFFFFFFFF, true)
     assert.equal(-1, longVal.low)
     assert.equal(-1, longVal.high)
     assert.equal(true, longVal.unsigned)


### PR DESCRIPTION
To lighten project and to switch to a more conventional .new() constructor fn. Fixes #33.